### PR TITLE
refactor(sound): replace DTO with id in delete request

### DIFF
--- a/src/main/java/net/onelitefeather/vulpes/backend/controller/SoundController.java
+++ b/src/main/java/net/onelitefeather/vulpes/backend/controller/SoundController.java
@@ -376,7 +376,7 @@ public class SoundController {
     @Produces(MediaType.APPLICATION_JSON)
     public HttpResponse<SoundResponseDTO> deleteSource(
             @PathVariable("id") UUID soundEventId,
-            @Body SoundFileSourceDTO sourceDTO
+            @Body UUID sourceDTO
     ) {
         SoundResponseDTO result = soundService.deleteLinkedSource(soundEventId, sourceDTO);
         return HttpResponse.ok(result);

--- a/src/main/java/net/onelitefeather/vulpes/backend/controller/SoundController.java
+++ b/src/main/java/net/onelitefeather/vulpes/backend/controller/SoundController.java
@@ -12,6 +12,8 @@ import io.micronaut.http.annotation.PathVariable;
 import io.micronaut.http.annotation.Post;
 import io.micronaut.http.annotation.Produces;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -268,30 +270,30 @@ public class SoundController {
      * Creates a new SoundFileSource and links it to a SoundEventEntity by ID.
      *
      * @param soundEventId the ID of the SoundEventEntity
-     * @param sourceDTO the DTO containing source data
+     * @param sourceDTO    the DTO containing source data
      * @return the created SoundFileSourceDTO
      */
     @Operation(
-        summary = "Create and link a SoundFileSource",
-        operationId = "createAndLinkSoundFileSource",
-        description = "Creates a new SoundFileSource and links it to a SoundEventEntity by its ID.",
-        tags = {"Sound"}
+            summary = "Create and link a SoundFileSource",
+            operationId = "createAndLinkSoundFileSource",
+            description = "Creates a new SoundFileSource and links it to a SoundEventEntity by its ID.",
+            tags = {"Sound"}
     )
     @ApiResponse(
-        responseCode = "200",
-        description = "The SoundFileSource was successfully created and linked.",
-        content = @Content(
-            mediaType = MediaType.APPLICATION_JSON,
-            schema = @Schema(implementation = SoundResponseDTO.SoundFileSourceDTO.class)
-        )
+            responseCode = "200",
+            description = "The SoundFileSource was successfully created and linked.",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON,
+                    schema = @Schema(implementation = SoundResponseDTO.SoundFileSourceDTO.class)
+            )
     )
     @ApiResponse(
-        responseCode = "404",
-        description = "The SoundEventEntity was not found.",
-        content = @Content(
-            mediaType = MediaType.APPLICATION_JSON,
-            schema = @Schema(implementation = SoundResponseDTO.SoundFileSourceDTO.class)
-        )
+            responseCode = "404",
+            description = "The SoundEventEntity was not found.",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON,
+                    schema = @Schema(implementation = SoundResponseDTO.SoundFileSourceDTO.class)
+            )
     )
     @Post("{id}/sources")
     @Produces(MediaType.APPLICATION_JSON)
@@ -307,7 +309,7 @@ public class SoundController {
      * Updates an existing SoundFileSource linked to a SoundEventEntity by ID.
      *
      * @param soundEventId the ID of the SoundEventEntity
-     * @param sourceDTO the DTO containing updated source data
+     * @param sourceDTO    the DTO containing updated source data
      * @return the updated SoundFileSourceDTO
      */
     @Operation(
@@ -347,7 +349,7 @@ public class SoundController {
      * Deletes an existing SoundFileSource linked to a SoundEventEntity by ID.
      *
      * @param soundEventId the ID of the SoundEventEntity
-     * @param sourceDTO the DTO containing source data to delete
+     * @param soundId      the DTO containing source data to delete
      * @return the deleted SoundFileSourceDTO
      */
     @Operation(
@@ -372,19 +374,17 @@ public class SoundController {
                     schema = @Schema(implementation = SoundResponseDTO.SoundFileSourceDTO.class)
             )
     )
-    @Delete("{id}/sources/delete")
+    @Delete("{id}/sources/delete/{soundId}")
     @Produces(MediaType.APPLICATION_JSON)
     public HttpResponse<SoundResponseDTO> deleteSource(
+            @Parameter(name = "id", description = "The id of the sound event", in = ParameterIn.PATH, required = true)
             @PathVariable("id") UUID soundEventId,
-            @Body UUID sourceDTO
+            @Parameter(name = "soundID", description = "The id of the sound file", in = ParameterIn.PATH, required = true)
+            @PathVariable("soundId") UUID soundId
     ) {
-        SoundResponseDTO result = soundService.deleteLinkedSource(soundEventId, sourceDTO);
+        SoundResponseDTO result = soundService.deleteLinkedSource(soundEventId, soundId);
         return HttpResponse.ok(result);
     }
-
-
-
-
 
 
 }

--- a/src/main/java/net/onelitefeather/vulpes/backend/service/SoundService.java
+++ b/src/main/java/net/onelitefeather/vulpes/backend/service/SoundService.java
@@ -72,25 +72,28 @@ public interface SoundService {
 
     /**
      * Creates a new sound file source and links it to a sound event.
+     *
      * @param soundEventId the ID of the sound event to link the source to
-     * @param sourceDTO the source data to create
+     * @param sourceDTO    the source data to create
      * @return the created source response
      */
     SoundResponseDTO createAndLinkSource(UUID soundEventId, SoundFileSourceDTO sourceDTO);
 
     /**
      * Updates an existing sound file source linked to a sound event by ID.
+     *
      * @param soundEventId the ID of the sound event
-     * @param sourceDTO the source data to update
+     * @param sourceDTO    the source data to update
      * @return the updated source response
      */
     SoundResponseDTO updateLinkedSource(UUID soundEventId, SoundFileSourceDTO sourceDTO);
 
     /**
      * Deletes an existing sound file source linked to a sound event by ID.
+     *
      * @param soundEventId the ID of the sound event
-     * @param sourceDTO the source data to delete
+     * @param sourceId     the ID of the source to delete
      * @return the deleted source response
      */
-    SoundResponseDTO deleteLinkedSource(UUID soundEventId, SoundFileSourceDTO sourceDTO);
+    SoundResponseDTO deleteLinkedSource(UUID soundEventId, UUID sourceId);
 }

--- a/src/main/java/net/onelitefeather/vulpes/backend/service/impl/SoundServiceImpl.java
+++ b/src/main/java/net/onelitefeather/vulpes/backend/service/impl/SoundServiceImpl.java
@@ -140,8 +140,8 @@ public class SoundServiceImpl implements SoundService {
 
     @Override
     @Transactional
-    public SoundResponseDTO.SoundFileSourceDTO deleteLinkedSource(UUID soundEventId, SoundFileSourceDTO sourceDTO) {
-        if (soundEventId == null || sourceDTO == null || sourceDTO.id() == null) {
+    public SoundResponseDTO.SoundFileSourceDTO deleteLinkedSource(UUID soundEventId, UUID sourceID) {
+        if (soundEventId == null || sourceID == null) {
             throw new IllegalArgumentException("SoundEventId and SourceDTO and SourceDTO.Id must not be null");
         }
 
@@ -154,12 +154,12 @@ public class SoundServiceImpl implements SoundService {
                 .stream()
                 .filter(SoundResponseDTO.SoundFileSourceDTO.class::isInstance)
                 .map(SoundResponseDTO.SoundFileSourceDTO.class::cast)
-                .filter(s -> s.id().equals(sourceDTO.id()))
+                .filter(s -> s.id().equals(sourceID))
                 .findFirst();
         if (existingSourceOpt.isEmpty()) {
             throw new IllegalArgumentException("Sound source not found for the given sound event");
         }
-        soundFileSourceRepository.deleteById(sourceDTO.id());
+        soundFileSourceRepository.deleteById(sourceID);
         return existingSourceOpt.get();
     }
 }

--- a/src/test/java/net/onelitefeather/vulpes/backend/controller/SoundControllerTest.java
+++ b/src/test/java/net/onelitefeather/vulpes/backend/controller/SoundControllerTest.java
@@ -76,7 +76,7 @@ class SoundControllerTest {
         }
 
         @Override
-        public SoundResponseDTO.SoundFileSourceDTO deleteLinkedSource(UUID soundEventId, SoundFileSourceDTO sourceDTO) {
+        public SoundResponseDTO.SoundFileSourceDTO deleteLinkedSource(UUID soundEventId, UUID sourceDTO) {
             return sourceResponse;
         }
     }


### PR DESCRIPTION
## Proposed changes

The pull request changes the parameter usage in the `DELETE` request of the `{id}/sources/delete` endpoint in the `SoundController`.  With the current implementation there is the problem that it requires the complete `SoundFileSourceDTO` to get the id from it. This is a bit stupid and requires more data which must be send over the network. 

So this pull request changes the required parameter to the id from the model which is must better for the network and reduces complexity.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)