### PR TITLE
feat(ci): publish snapshots and build docker images on every main push

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -82,6 +82,9 @@ jobs:
       version: ${{ github.event_name == 'workflow_dispatch' && inputs.docker_version || needs.release-please.outputs.version }}
       setup-java: true
       build-command: "./gradlew jar optimizedBuildLayers optimizedDockerfile -Pversion=$VERSION"
+      build-env: |
+        ONELITEFEATHER_MAVEN_USERNAME=${{ secrets.ONELITEFEATHER_MAVEN_USERNAME }}
+        ONELITEFEATHER_MAVEN_PASSWORD=${{ secrets.ONELITEFEATHER_MAVEN_PASSWORD }}
       context: "./build/docker/optimized"
       blob-chunk: "90000000"   # ~90 MB, under the 100 MB Cloudflare cap
       req-concurrent: "4"
@@ -110,6 +113,9 @@ jobs:
       version: ${{ needs.version.outputs.version }}
       setup-java: true
       build-command: "./gradlew jar optimizedBuildLayers optimizedDockerfile -Pversion=$VERSION"
+      build-env: |
+        ONELITEFEATHER_MAVEN_USERNAME=${{ secrets.ONELITEFEATHER_MAVEN_USERNAME }}
+        ONELITEFEATHER_MAVEN_PASSWORD=${{ secrets.ONELITEFEATHER_MAVEN_PASSWORD }}
       context: "./build/docker/optimized"
       blob-chunk: "90000000"   # ~90 MB, under the 100 MB Cloudflare cap
       req-concurrent: "4"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -55,7 +55,7 @@ jobs:
           echo "is_snapshot=$IS_SNAPSHOT" >> "$GITHUB_OUTPUT"
           echo "Resolved version '$VERSION' (snapshot=$IS_SNAPSHOT)"
 
-  # ---- Release artifacts (on a real release-please release) ----
+  # ---- Maven publish ----
   publish:
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
@@ -65,32 +65,6 @@ jobs:
       java-distribution: "temurin"
     secrets: inherit
 
-  docker:
-    name: Build Docker Artifacts
-    needs: release-please
-    permissions:
-      contents: read
-      id-token: write   # keyless cosign signing via GitHub OIDC
-    # Runs on a real release, or on a manual dispatch to (re)publish a given version.
-    if: |
-      always() &&
-      ((github.event_name == 'push' && needs.release-please.outputs.release_created == 'true') ||
-       github.event_name == 'workflow_dispatch')
-    uses: OneLiteFeatherNET/workflows/.github/workflows/docker-publish.yml@v2.3.0
-    with:
-      image-name: "onelitefeather/vulpes-backend"
-      version: ${{ github.event_name == 'workflow_dispatch' && inputs.docker_version || needs.release-please.outputs.version }}
-      setup-java: true
-      build-command: "./gradlew jar optimizedBuildLayers optimizedDockerfile -Pversion=$VERSION"
-      build-env: |
-        ONELITEFEATHER_MAVEN_USERNAME=${{ secrets.ONELITEFEATHER_MAVEN_USERNAME }}
-        ONELITEFEATHER_MAVEN_PASSWORD=${{ secrets.ONELITEFEATHER_MAVEN_PASSWORD }}
-      context: "./build/docker/optimized"
-      blob-chunk: "90000000"   # ~90 MB, under the 100 MB Cloudflare cap
-      req-concurrent: "4"
-    secrets: inherit
-
-  # ---- Snapshot artifacts (on every non-release push to main) ----
   publish-snapshot:
     needs: [release-please, version]
     if: needs.version.outputs.is_snapshot == 'true'
@@ -100,9 +74,59 @@ jobs:
       java-distribution: "temurin"
     secrets: inherit
 
+  # ---- Release Docker image (Gradle produces the context, docker-publish builds it) ----
+  build-context:
+    name: Build Docker context
+    needs: release-please
+    # On a real release, or on a manual dispatch to (re)publish a given version.
+    if: |
+      always() &&
+      ((github.event_name == 'push' && needs.release-please.outputs.release_created == 'true') ||
+       github.event_name == 'workflow_dispatch')
+    uses: OneLiteFeatherNET/workflows/.github/workflows/gradle-docker-context.yml@v2.3.0
+    with:
+      version: ${{ github.event_name == 'workflow_dispatch' && inputs.docker_version || needs.release-please.outputs.version }}
+      gradle-command: "./gradlew jar optimizedBuildLayers optimizedDockerfile -Pversion=$VERSION"
+      context-path: "build/docker/optimized"
+      artifact-name: "docker-context-release"
+    secrets: inherit
+
+  docker:
+    name: Build Docker Artifacts
+    needs: [release-please, build-context]
+    permissions:
+      contents: read
+      id-token: write   # keyless cosign signing via GitHub OIDC
+    if: |
+      always() && needs.build-context.result == 'success' &&
+      ((github.event_name == 'push' && needs.release-please.outputs.release_created == 'true') ||
+       github.event_name == 'workflow_dispatch')
+    uses: OneLiteFeatherNET/workflows/.github/workflows/docker-publish.yml@v2.3.0
+    with:
+      image-name: "onelitefeather/vulpes-backend"
+      version: ${{ github.event_name == 'workflow_dispatch' && inputs.docker_version || needs.release-please.outputs.version }}
+      context: "build/docker/optimized"
+      artifact-name: "docker-context-release"
+      blob-chunk: "90000000"   # ~90 MB, under the 100 MB Cloudflare cap
+      req-concurrent: "4"
+    secrets: inherit
+
+  # ---- Snapshot Docker image (on every non-release push to main) ----
+  build-context-snapshot:
+    name: Build Docker context (snapshot)
+    needs: [release-please, version]
+    if: needs.version.outputs.is_snapshot == 'true'
+    uses: OneLiteFeatherNET/workflows/.github/workflows/gradle-docker-context.yml@v2.3.0
+    with:
+      version: ${{ needs.version.outputs.version }}
+      gradle-command: "./gradlew jar optimizedBuildLayers optimizedDockerfile -Pversion=$VERSION"
+      context-path: "build/docker/optimized"
+      artifact-name: "docker-context-snapshot"
+    secrets: inherit
+
   docker-snapshot:
     name: Build Docker Artifacts (snapshot)
-    needs: [release-please, version]
+    needs: [version, build-context-snapshot]
     permissions:
       contents: read
       id-token: write   # keyless cosign signing via GitHub OIDC
@@ -111,12 +135,8 @@ jobs:
     with:
       image-name: "onelitefeather/vulpes-backend"
       version: ${{ needs.version.outputs.version }}
-      setup-java: true
-      build-command: "./gradlew jar optimizedBuildLayers optimizedDockerfile -Pversion=$VERSION"
-      build-env: |
-        ONELITEFEATHER_MAVEN_USERNAME=${{ secrets.ONELITEFEATHER_MAVEN_USERNAME }}
-        ONELITEFEATHER_MAVEN_PASSWORD=${{ secrets.ONELITEFEATHER_MAVEN_PASSWORD }}
-      context: "./build/docker/optimized"
+      context: "build/docker/optimized"
+      artifact-name: "docker-context-snapshot"
       blob-chunk: "90000000"   # ~90 MB, under the 100 MB Cloudflare cap
       req-concurrent: "4"
     secrets: inherit

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,6 +2,13 @@ name: release-please
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      docker_version:
+        description: "Version to (re)build & push the Docker image for, e.g. 2.0.0 (no leading v). Runs only the docker job."
+        required: true
+        type: string
+
 permissions:
   contents: write
   pull-requests: write
@@ -22,10 +29,37 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
+  # Resolves the current project version from gradle.properties for non-release
+  # pushes, so the snapshot jobs below know whether (and at which version) to run.
+  version:
+    needs: release-please
+    if: github.event_name == 'push' && needs.release-please.outputs.release_created != 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.read.outputs.version }}
+      is_snapshot: ${{ steps.read.outputs.is_snapshot }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Read version
+        id: read
+        shell: bash
+        run: |
+          VERSION="$(grep -E '^version=' gradle.properties | head -n1 | cut -d= -f2 | cut -d'#' -f1 | xargs)"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          # Mirror the snapshot routing in build.gradle.kts (SNAPSHOT/BETA/ALPHA).
+          case "$VERSION" in
+            *SNAPSHOT*|*BETA*|*ALPHA*) IS_SNAPSHOT=true ;;
+            *)                          IS_SNAPSHOT=false ;;
+          esac
+          echo "is_snapshot=$IS_SNAPSHOT" >> "$GITHUB_OUTPUT"
+          echo "Resolved version '$VERSION' (snapshot=$IS_SNAPSHOT)"
+
+  # ---- Release artifacts (on a real release-please release) ----
   publish:
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
-    uses: OneLiteFeatherNET/workflows/.github/workflows/gradle-publish.yml@v2.2.0
+    uses: OneLiteFeatherNET/workflows/.github/workflows/gradle-publish.yml@v2.3.0
     with:
       java-version: "25.0.3"
       java-distribution: "temurin"
@@ -42,10 +76,38 @@ jobs:
       always() &&
       ((github.event_name == 'push' && needs.release-please.outputs.release_created == 'true') ||
        github.event_name == 'workflow_dispatch')
-    uses: OneLiteFeatherNET/workflows/.github/workflows/docker-publish.yml@v2.2.0
+    uses: OneLiteFeatherNET/workflows/.github/workflows/docker-publish.yml@v2.3.0
     with:
       image-name: "onelitefeather/vulpes-backend"
       version: ${{ github.event_name == 'workflow_dispatch' && inputs.docker_version || needs.release-please.outputs.version }}
+      setup-java: true
+      build-command: "./gradlew jar optimizedBuildLayers optimizedDockerfile -Pversion=$VERSION"
+      context: "./build/docker/optimized"
+      blob-chunk: "90000000"   # ~90 MB, under the 100 MB Cloudflare cap
+      req-concurrent: "4"
+    secrets: inherit
+
+  # ---- Snapshot artifacts (on every non-release push to main) ----
+  publish-snapshot:
+    needs: [release-please, version]
+    if: needs.version.outputs.is_snapshot == 'true'
+    uses: OneLiteFeatherNET/workflows/.github/workflows/gradle-publish.yml@v2.3.0
+    with:
+      java-version: "25.0.3"
+      java-distribution: "temurin"
+    secrets: inherit
+
+  docker-snapshot:
+    name: Build Docker Artifacts (snapshot)
+    needs: [release-please, version]
+    permissions:
+      contents: read
+      id-token: write   # keyless cosign signing via GitHub OIDC
+    if: needs.version.outputs.is_snapshot == 'true'
+    uses: OneLiteFeatherNET/workflows/.github/workflows/docker-publish.yml@v2.3.0
+    with:
+      image-name: "onelitefeather/vulpes-backend"
+      version: ${{ needs.version.outputs.version }}
       setup-java: true
       build-command: "./gradlew jar optimizedBuildLayers optimizedDockerfile -Pversion=$VERSION"
       context: "./build/docker/optimized"


### PR DESCRIPTION
## Problem

The release-please pipeline published Maven artifacts and Docker images **only on a real release**, and the release Docker build was broken: release `2.0.0` (#129) failed because the Docker job couldn't resolve the private `net.onelitefeather:vulpes-model` dependency (`Username must not be null!`). Snapshots (`2.0.1-SNAPSHOT`, …) never triggered publish or docker at all.

## Changes

- **Snapshots**: new `version` job reads `gradle.properties` on non-release pushes; `publish-snapshot` + `docker-snapshot` run on every non-release push when the version is SNAPSHOT/BETA/ALPHA. Maven publish auto-routes to the snapshot repo.
- **Docker build fixed & decoupled from Gradle**: the Gradle step that generates the Micronaut optimized context now runs in the new reusable `gradle-docker-context.yml` producer (carries the private Maven credentials via `secrets: inherit`) and uploads the context as an artifact. The toolchain-agnostic `docker-publish.yml` consumes it via `artifact-name`. Both release and snapshot paths run `build-context* → docker*`.
- Added the `workflow_dispatch` trigger the `docker` job already referenced (manual image re-publish), matching Otis.

## ⚠️ Merge order

Depends on **OneLiteFeatherNET/workflows#15** (merged + released as **`v2.3.0`**) first — the `@v2.3.0` refs won't resolve until then. Sequence:
1. Merge & release workflows#15 → `v2.3.0`.
2. Merge OneLiteFeatherNET/Otis#131 and this PR.

## Verification

- Version extraction tested locally → `2.0.1-SNAPSHOT` ⇒ `is_snapshot=true`.
- All workflow YAML validated.
- Root cause confirmed from the failed run log of release `2.0.0` (#129).

🤖 Generated with [Claude Code](https://claude.com/claude-code)