### PR TITLE
feat: OpenTelemetry tracing + JSON logging for Grafana Loki

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -100,7 +100,9 @@ micronaut {
         optimizeClassLoading = false
         deduceEnvironment = true
         optimizeNetty = true
-        replaceLogbackXml = true
+        // Keep logback.xml parsed at runtime so the env-driven JSON/plain switch
+        // and ${...} substitutions work in the optimized (Docker/prod) jar.
+        replaceLogbackXml = false
     }
 }
 tasks {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,17 @@ dependencies {
     implementation(mn.snakeyaml)
     implementation(mn.logback.core)
     implementation(mn.logback.classic)
+    // Distributed tracing (OpenTelemetry). Spans/export are only active when
+    // OTEL_TRACES_EXPORTER=otlp is set (prod/Docker) — see application.yml.
+    implementation(mn.micronaut.tracing.opentelemetry.http)
+    implementation(mn.micronaut.tracing.opentelemetry.jdbc)
+    implementation(libs.opentelemetry.exporter.otlp)
+    // Structured JSON logging for Grafana Loki + trace/log correlation.
+    // logstash encoder renders JSON; the OTel MDC appender injects trace_id/span_id.
+    implementation(libs.logstash.logback.encoder)
+    implementation(libs.opentelemetry.logback.mdc)
+    // Enables the <if>/<then>/<else> conditional in logback.xml.
+    runtimeOnly(libs.janino)
     // Vulpes API
     implementation(libs.vulpes.api)
     // UUID Creator

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -40,6 +40,9 @@ dependencyResolutionManagement {
             version("hibernate.validator", "9.1.0.Final")
             version("jakarta.validation", "3.1.1")
             version("cyclonedx", "3.2.4")
+            version("logstash.logback.encoder", "8.1")
+            version("janino", "3.1.12")
+            version("opentelemetry.instrumentation.alpha", "2.20.1-alpha")
 
             library("uuid.creator", "com.github.f4b6a3", "uuid-creator").versionRef("uuid.creator")
             library("vulpes.api", "net.onelitefeather", "vulpes-model").versionRef("vulpes.model")
@@ -49,6 +52,13 @@ dependencyResolutionManagement {
 
             library("hibernate.validator", "org.hibernate.validator", "hibernate-validator").versionRef("hibernate.validator")
             library("jakarta.validation", "jakarta.validation", "jakarta.validation-api").versionRef("jakarta.validation")
+
+            // Observability — JSON logging + OpenTelemetry (see build.gradle.kts).
+            // OTLP exporter version is managed by the Micronaut platform BOM.
+            library("logstash.logback.encoder", "net.logstash.logback", "logstash-logback-encoder").versionRef("logstash.logback.encoder")
+            library("janino", "org.codehaus.janino", "janino").versionRef("janino")
+            library("opentelemetry.exporter.otlp", "io.opentelemetry", "opentelemetry-exporter-otlp").withoutVersion()
+            library("opentelemetry.logback.mdc", "io.opentelemetry.instrumentation", "opentelemetry-logback-mdc-1.0").versionRef("opentelemetry.instrumentation.alpha")
 
             plugin("micronaut.application", "io.micronaut.application").versionRef("micronaut")
             plugin("micronaut.aot", "io.micronaut.aot").versionRef("micronaut")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,6 +29,29 @@ micronaut:
         paths: classpath:META-INF/swagger/views/swagger-ui
         mapping: /swagger-ui/**
 
+# OpenTelemetry — tracing is disabled unless OTEL_TRACES_EXPORTER=otlp is set
+# (do this in the Docker/prod container). Metrics stay on Prometheus/Micrometer.
+otel:
+  service:
+    name: ${OTEL_SERVICE_NAME:vulpes-backend}
+  traces:
+    exporter: ${OTEL_TRACES_EXPORTER:none}
+  metrics:
+    exporter: none
+  logs:
+    exporter: none
+  exporter:
+    otlp:
+      protocol: grpc
+      endpoint: ${OTEL_EXPORTER_OTLP_ENDPOINT:`http://localhost:4317`}
+  exclusions:
+    - /health
+    - /health/.*
+    - /prometheus
+    - /swagger
+    - /swagger/.*
+    - /swagger-ui/.*
+
 datasources:
   default:
     url: jdbc:mariadb://localhost:3336/vulpes

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,10 +1,40 @@
 <configuration>
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
-        </encoder>
+    <!--
+      Logging is human-readable by default (local dev) and switches to structured
+      JSON on stdout when LOG_JSON=true (set this in the Docker/prod container) so
+      Grafana Loki can index the fields. The OpenTelemetry MDC appender injects
+      trace_id/span_id/trace_flags into the MDC for log <-> trace correlation.
+    -->
+    <property name="LOG_JSON" value="${LOG_JSON:-false}"/>
+
+    <if condition='"true".equalsIgnoreCase(property("LOG_JSON"))'>
+        <then>
+            <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+                <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+                    <fieldNames>
+                        <timestamp>timestamp</timestamp>
+                        <message>message</message>
+                        <logger>logger</logger>
+                        <thread>thread</thread>
+                        <level>level</level>
+                    </fieldNames>
+                </encoder>
+            </appender>
+        </then>
+        <else>
+            <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+                <encoder>
+                    <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
+                </encoder>
+            </appender>
+        </else>
+    </if>
+
+    <appender name="OTEL" class="io.opentelemetry.instrumentation.logback.mdc.v1_0.OpenTelemetryAppender">
+        <appender-ref ref="STDOUT"/>
     </appender>
+
     <root level="INFO">
-        <appender-ref ref="STDOUT" />
+        <appender-ref ref="OTEL"/>
     </root>
 </configuration>


### PR DESCRIPTION
## Why

Structured **JSON logs** that Grafana Loki can index cleanly, plus **OpenTelemetry tracing** with log↔trace correlation. Mirrors the setup added to the Otis backend. Metrics stay on the existing Prometheus/Micrometer path.

## What

- **JSON logging** (`logback.xml`): structured JSON on stdout when `LOG_JSON=true`; local dev keeps the human-readable pattern. Each line carries `trace_id`/`span_id` via the OpenTelemetry MDC appender.
- **OpenTelemetry tracing** (`application.yml`): disabled by default (`otel.traces.exporter: none`), activates when `OTEL_TRACES_EXPORTER=otlp` is set, exporting spans over OTLP gRPC. `/health`, `/prometheus`, `/swagger*` excluded.
- **Dependencies** added to the `libs` version catalog (OTLP exporter version managed by the Micronaut platform BOM).
- **AOT**: `replaceLogbackXml` disabled so the env-driven switch works at runtime in the optimized jar.

## Container env vars (prod/Docker)

```bash
LOG_JSON=true
OTEL_TRACES_EXPORTER=otlp
OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4317   # your Alloy/Collector (gRPC)
OTEL_SERVICE_NAME=vulpes-backend                 # optional
```

Without these (local dev) behavior is unchanged: readable logs, no export.

## Grafana

- Loki's JSON parser picks up `level`/`logger`/`thread` etc.
- Set a Loki derived field on `trace_id` → Tempo for log-to-trace jumps.

## Verification

- Prod AOT path `./gradlew jar optimizedBuildLayers optimizedDockerfile` ✅ BUILD SUCCESSFUL
- Catalog aliases resolve: tracing-opentelemetry 7.2.0, exporter-otlp → 1.54.1, logback-mdc 2.20.1-alpha, logstash-encoder 8.1, janino 3.1.12

Not done: full test run (Testcontainers/MariaDB) and runtime smoke test of an actual JSON line / live span.