### PR TITLE
feat: enable /health and /prometheus management endpoints

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     implementation(mn.micronaut.openapi)
     implementation(mn.validation)
     implementation(mn.swagger.core)
+    implementation(mn.micronaut.management)
     implementation(mn.micronaut.micrometer.core)
     implementation(mn.micronaut.micrometer.registry.prometheus)
     // External Dependencies

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,6 +28,24 @@ micronaut:
       swagger-ui:
         paths: classpath:META-INF/swagger/views/swagger-ui
         mapping: /swagger-ui/**
+  metrics:
+    enabled: true
+    export:
+      prometheus:
+        enabled: true
+        step: PT1M
+        descriptions: true
+
+# Management endpoints — /health for liveness/readiness probes,
+# /prometheus for metrics scraping (both non-sensitive for internal scraping).
+endpoints:
+  health:
+    enabled: true
+    sensitive: false
+    details-visible: ANONYMOUS
+  prometheus:
+    enabled: true
+    sensitive: false
 
 # OpenTelemetry — tracing is disabled unless OTEL_TRACES_EXPORTER=otlp is set
 # (do this in the Docker/prod container). Metrics stay on Prometheus/Micrometer.


### PR DESCRIPTION
## Why

The observability work (JSON logging + OpenTelemetry) was merged and released as 2.2.0, but the **health/metrics management endpoints** were not part of that merge. This brings them in against current `main`. Mirrors Otis.

## What

- **`build.gradle.kts`**: add `micronaut-management` (required to expose `/health` and `/prometheus`; it was missing).
- **`application.yml`**: enable the Micrometer Prometheus export and expose `/health` (details visible) and `/prometheus`, both `sensitive: false` for internal scraping.

## Endpoints

- `GET /health` — liveness/readiness probes
- `GET /prometheus` — metrics scrape target

## Verification

- `./gradlew compileJava` ✅
- Cherry-picked cleanly from the original observability branch onto current `main`.

Note: a pre-existing schema-generation error (`SoundEventEntity.soundData` → unknown data type OBJECT) currently blocks full app startup in the dev `run` path; it is unrelated to this change.