### PR TITLE
fix(publish): publish only the thin jar (drop dist tar/zip)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -129,12 +129,10 @@ tasks {
 
 publishing {
     publications.create<MavenPublication>("maven") {
-        artifact(project.tasks.optimizedJitJar)
-        artifact(project.tasks.optimizedRunnerJitJar)
-        artifact(project.tasks.runnerJar)
+        // Only the thin application jar is published. The fat runner jars and the
+        // full distribution tar/zip bundle every dependency; the runnable artifact
+        // is the Docker image, not a Maven artifact.
         artifact(project.tasks.jar)
-        artifact(project.tasks.optimizedDistTar)
-        artifact(project.tasks.optimizedDistZip)
 
         version = rootProject.version as String
         artifactId = "vulpes-backend"


### PR DESCRIPTION
The Maven publication uploads the full application distribution (`optimizedDistTar` / `optimizedDistZip`) plus the fat runner jars, which bundle every dependency. For an application that's unnecessary bloat in the Maven repo — the runnable deliverable is the Docker image.

Reduce the publication to the thin `jar` (+ pom), matching the vulpes-generator setup (vulpes-generator#124).

🤖 Generated with [Claude Code](https://claude.com/claude-code)